### PR TITLE
Open interface for accessing a Basket batch in perform

### DIFF
--- a/lib/basket.rb
+++ b/lib/basket.rb
@@ -12,6 +12,10 @@ module Basket
     @config ||= {queue: Basket::Queue.new}
   end
 
+  def self.contents
+    @config[:queue].data
+  end
+
   def self.add(queue, data)
     queue_length = @config[:queue].push(queue, data)
     queue_class = Object.const_get(queue)

--- a/lib/basket.rb
+++ b/lib/basket.rb
@@ -23,4 +23,10 @@ module Basket
 
     queue_class.new.perform
   end
+
+  def self.clear_all
+    unless @config.nil?
+      @config[:queue] = Basket::Queue.new
+    end
+  end
 end

--- a/lib/basket/batcher.rb
+++ b/lib/basket/batcher.rb
@@ -13,5 +13,9 @@ module Basket
         @basket_options
       end
     end
+
+    def batch
+      @batch ||= Basket.config[:queue].pop_all(self.class.name)
+    end
   end
 end

--- a/spec/basket_spec.rb
+++ b/spec/basket_spec.rb
@@ -9,6 +9,19 @@ class DummyGroceryBasket
   end
 end
 
+class DummyStockBasket
+  include Basket::Batcher
+  basket_options size: 3
+
+  def perform
+    sell(batch)
+  end
+
+  def sell
+    puts ap batch
+  end
+end
+
 RSpec.describe Basket do
   it "has a version number" do
     expect(Basket::VERSION).not_to be nil
@@ -18,17 +31,43 @@ RSpec.describe Basket do
     expect(true).to eq(true)
   end
 
-  it "will perform an action when the basket is full" do
-    Basket.config
+  describe "#add" do
+    it "allows you to track multiple baskets" do
+      Basket.config
 
-    stubbed_basket = DummyGroceryBasket.new
-    allow(DummyGroceryBasket).to receive(:new).and_return(stubbed_basket)
-    allow(stubbed_basket).to receive(:perform).and_call_original
+      Basket.add("DummyGroceryBasket", :milk)
+      Basket.add("DummyStockBasket", {stock: "IBM", purchased_price: 13036})
 
-    Basket.add("DummyGroceryBasket", :milk)
-    Basket.add("DummyGroceryBasket", :cookies)
+      expect(Basket.contents).to eq({"DummyGroceryBasket" => [:milk], "DummyStockBasket" => [{purchased_price: 13036, stock: "IBM"}]})
+    end
+  end
 
-    expect(DummyGroceryBasket.basket_options_hash).to eq({size: 2})
-    expect(stubbed_basket).to have_received(:perform)
+  describe "#perform" do
+    it "will perform an action when the basket is full" do
+      Basket.config
+
+      stubbed_basket = DummyGroceryBasket.new
+      allow(DummyGroceryBasket).to receive(:new).and_return(stubbed_basket)
+      allow(stubbed_basket).to receive(:perform).and_call_original
+
+      Basket.add("DummyGroceryBasket", :milk)
+      Basket.add("DummyGroceryBasket", :cookies)
+
+      expect(DummyGroceryBasket.basket_options_hash).to eq({size: 2})
+      expect(stubbed_basket).to have_received(:perform)
+    end
+
+    it "resets"
+    it "will make the batch available to perform"
+  end
+
+  describe "#on_success" do
+    it "is called after perform"
+    it "is not called if perform raises an error"
+  end
+
+  describe "#on_failure" do
+    it "is called if perform raises an error"
+    it "has the error available to it so it can reraise or swallow that error?"
   end
 end


### PR DESCRIPTION
Open the interface for accessing a Basket batch so that the items pushed into the basket can be popped off the queue and used in the perform action.