### PR TITLE
on_success

### DIFF
--- a/lib/basket.rb
+++ b/lib/basket.rb
@@ -21,7 +21,9 @@ module Basket
     queue_class = Object.const_get(queue)
     return unless queue_length == queue_class.basket_options_hash[:size]
 
-    queue_class.new.perform
+    queue_instance = queue_class.new
+    queue_instance.perform
+    queue_instance.on_success
   end
 
   def self.clear_all

--- a/lib/basket/batcher.rb
+++ b/lib/basket/batcher.rb
@@ -17,5 +17,8 @@ module Basket
     def batch
       @batch ||= Basket.config[:queue].pop_all(self.class.name)
     end
+
+    def on_success
+    end
   end
 end

--- a/spec/basket_spec.rb
+++ b/spec/basket_spec.rb
@@ -46,9 +46,6 @@ class DummyFireworksBasket
   def perform
     raise "Boom"
   end
-
-  def on_success
-  end
 end
 
 RSpec.describe Basket do

--- a/spec/basket_spec.rb
+++ b/spec/basket_spec.rb
@@ -40,13 +40,12 @@ RSpec.describe Basket do
   end
 
   before do
+    Basket.config
     Basket.clear_all
   end
 
   describe "#add" do
     it "allows you to track multiple baskets" do
-      Basket.config
-
       Basket.add("DummyGroceryBasket", :milk)
       Basket.add("DummyStockBasket", {stock: "IBM", purchased_price: 13036})
 
@@ -56,8 +55,6 @@ RSpec.describe Basket do
 
   describe "#perform" do
     it "will perform an action when the basket is full" do
-      Basket.config
-
       stubbed_basket = DummyGroceryBasket.new
       allow(DummyGroceryBasket).to receive(:new).and_return(stubbed_basket)
       allow(stubbed_basket).to receive(:perform).and_call_original
@@ -70,8 +67,6 @@ RSpec.describe Basket do
     end
 
     it "processes the batch" do
-      Basket.config
-
       stubbed_basket = DummyStockBasket.new
       allow(DummyStockBasket).to receive(:new).and_return(stubbed_basket)
       allow(stubbed_basket).to receive(:perform).and_call_original


### PR DESCRIPTION
I'm not sure I'm particularly wild about defining a default on_success on Basket::Batcher, but it works for now.

I also decided I don't love defining classes used by the baskets as namespaced within the baskets, mostly because it feels like that's not how its going to be used.  But I did it for now!

Closes #4 