### PR TITLE
Use namespaced redis to ensure scoped access.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,5 @@ gem "mocktail"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "simplecov", require: false, group: :test
-gem 'simplecov-json', :require => false, :group => :test
+gem "simplecov-json", require: false, group: :test
 gem "standard", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     basket (0.0.2)
       redis
+      redis-namespace
 
 GEM
   remote: https://rubygems.org/
@@ -61,6 +62,8 @@ GEM
       redis-client (>= 0.9.0)
     redis-client (0.14.0)
       connection_pool
+    redis-namespace (1.10.0)
+      redis (>= 4)
     regexp_parser (2.7.0)
     rexml (3.2.5)
     rspec (3.12.0)

--- a/basket.gemspec
+++ b/basket.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "redis"
+  spec.add_dependency "redis-namespace"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/spec/basket/backend_adapter/redis_backend_spec.rb
+++ b/spec/basket/backend_adapter/redis_backend_spec.rb
@@ -1,4 +1,18 @@
 RSpec.describe Basket::BackendAdapter::RedisBackend do
+  describe "#data" do
+    it "returns all the basket entries" do
+      backend = described_class.new
+      backend.push("test_queue_1", {a: 1})
+      backend.push("test_queue_1", {a: 2})
+      backend.push("test_queue_2", {b: 1})
+
+      expect(backend.data).to eq({
+        "test_queue_1" => [{a: 1}, {a: 2}],
+        "test_queue_2" => [{b: 1}]
+      })
+    end
+  end
+
   describe "#push" do
     it "pushes an item into the given queue" do
       result = described_class.new.push("test_queue", {a: 1})


### PR DESCRIPTION
Use `redis-namespace` to avoid any custom "basket" name-spacing issues in redis. This also uses `scan_each` over `keys` [as `keys` can block redis IO](https://redis.io/commands/scan/).