### PR TITLE
Serialize `RedisBackend` entries as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ while chicken.laying? do
 end
 ```
 
-The item added to the basket can be any data you want!  If you are using the in memory Queue, it is fine to store Ruby objects, but if you have a different backend, it might be better to stick to easily serializable objects.
+The item added to the basket can be any data you want!  If you are using the in memory Queue, it is fine to store Ruby objects, but if you have a different backend, must be JSON serializable via `to_json`.
 
 ```ruby
 class QuicheBasket

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ end
 
 The defaults for a redis backend are the standard `"127.0.0.1"`, `6379`, `15` with a namespace of `:basket`.
 
-The default for the backend is the HashBackend, which can be set by passing `:hash` to `config.backend`, but you don't have to do that.  Because it's the default!
+The default for the backend is the MemoryBackend, which can be set by passing `:memory` to `config.backend`, but you don't have to do that.  Because it's the default!
 
 For the redis configuration, you can alternatively pass a url, thusly:
 

--- a/lib/basket.rb
+++ b/lib/basket.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "basket/backend_adapter"
-require_relative "basket/backend_adapter/hash_backend"
+require_relative "basket/backend_adapter/memory_backend"
 require_relative "basket/backend_adapter/redis_backend"
 require_relative "basket/batcher"
 require_relative "basket/configuration"

--- a/lib/basket/backend_adapter/memory_backend.rb
+++ b/lib/basket/backend_adapter/memory_backend.rb
@@ -1,6 +1,6 @@
 module Basket
   class BackendAdapter
-    class HashBackend < Basket::BackendAdapter
+    class MemoryBackend < Basket::BackendAdapter
       def initialize
         @data = {}
       end

--- a/lib/basket/backend_adapter/redis_backend.rb
+++ b/lib/basket/backend_adapter/redis_backend.rb
@@ -1,4 +1,5 @@
 require "redis-namespace"
+require "json"
 
 module Basket
   class BackendAdapter
@@ -25,9 +26,7 @@ module Basket
       end
 
       def push(queue, data)
-        # TODO: should we use JSON vs Marshal?
-        marshalled_data = Marshal.dump(data)
-        @client.lpush(queue, marshalled_data)
+        @client.lpush(queue, serialize_data(data))
       end
 
       def length(queue)
@@ -44,8 +43,12 @@ module Basket
 
       private
 
+      def serialize_data(data)
+        JSON.generate(data)
+      end
+
       def deserialized_queue_data(queue)
-        @client.lrange(queue, 0, -1).reverse.map { |marshalled_data| Marshal.load(marshalled_data) }
+        @client.lrange(queue, 0, -1).reverse.map { |serialized_data| JSON.parse(serialized_data) }
       end
 
       def select_redis_connection

--- a/lib/basket/configuration.rb
+++ b/lib/basket/configuration.rb
@@ -7,15 +7,15 @@ module Basket
       @redis_host = "127.0.0.1"
       @redis_port = 6379
       @redis_db = 15
-      @backend = BackendAdapter::HashBackend
+      @backend = BackendAdapter::MemoryBackend
       @namespace = :basket
       @redis_url = nil
     end
 
     def backend=(backend)
       case backend
-      when :hash
-        @backend = BackendAdapter::HashBackend
+      when :memory
+        @backend = BackendAdapter::MemoryBackend
       when :redis
         @backend = BackendAdapter::RedisBackend
       else

--- a/spec/basket/backend_adapter/memory_backend_spec.rb
+++ b/spec/basket/backend_adapter/memory_backend_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Basket::BackendAdapter::HashBackend do
+RSpec.describe Basket::BackendAdapter::MemoryBackend do
   describe "#data" do
     it "returns all the basket entries" do
       backend = described_class.new

--- a/spec/basket/backend_adapter/redis_backend_spec.rb
+++ b/spec/basket/backend_adapter/redis_backend_spec.rb
@@ -2,20 +2,20 @@ RSpec.describe Basket::BackendAdapter::RedisBackend do
   describe "#data" do
     it "returns all the basket entries" do
       backend = described_class.new
-      backend.push("test_queue_1", {a: 1})
-      backend.push("test_queue_1", {a: 2})
-      backend.push("test_queue_2", {b: 1})
+      backend.push("test_queue_1", {"a" => 1})
+      backend.push("test_queue_1", {"a" => 2})
+      backend.push("test_queue_2", {"b" => 1})
 
       expect(backend.data).to eq({
-        "test_queue_1" => [{a: 1}, {a: 2}],
-        "test_queue_2" => [{b: 1}]
+        "test_queue_1" => [{"a" => 1}, {"a" => 2}],
+        "test_queue_2" => [{"b" => 1}]
       })
     end
   end
 
   describe "#push" do
     it "pushes an item into the given queue" do
-      result = described_class.new.push("test_queue", {a: 1})
+      result = described_class.new.push("test_queue", {"a" => 1})
 
       expect(result).to eq(1)
     end
@@ -24,8 +24,8 @@ RSpec.describe Basket::BackendAdapter::RedisBackend do
   describe "#length" do
     it "returns the length of the given queue" do
       backend = described_class.new
-      backend.push("test_queue", {a: 1})
-      backend.push("test_queue", {b: 2})
+      backend.push("test_queue", {"a" => 1})
+      backend.push("test_queue", {"b" => 2})
 
       expect(backend.length("test_queue")).to eq(2)
     end

--- a/spec/basket/configuration_spec.rb
+++ b/spec/basket/configuration_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Basket::Configuration do
       expect(configuration.redis_host).to eq("127.0.0.1")
       expect(configuration.redis_port).to eq(6379)
       expect(configuration.redis_db).to eq(15)
-      expect(configuration.backend).to eq(Basket::BackendAdapter::HashBackend)
+      expect(configuration.backend).to eq(Basket::BackendAdapter::MemoryBackend)
       expect(configuration.namespace).to eq(:basket)
       expect(configuration.redis_url).to eq(nil)
     end
@@ -32,10 +32,10 @@ RSpec.describe Basket::Configuration do
   end
 
   describe "#backend=" do
-    it "sets the hash backend when :hash is passed" do
+    it "sets the memory backend when :memory is passed" do
       configuration = Basket::Configuration.new
-      configuration.backend = :hash
-      expect(configuration.backend).to eq(Basket::BackendAdapter::HashBackend)
+      configuration.backend = :memory
+      expect(configuration.backend).to eq(Basket::BackendAdapter::MemoryBackend)
     end
 
     it "sets the redis backend when :redis is passed" do


### PR DESCRIPTION
While the Marshalling approach has more flexibility in what which values can be stored, it can be less stable and reliable than  storing entries in a JSON format.

It's also recommended by [Ruby's docs](https://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations) to avoid the Marshalling approach unless you know exactly what's being serialized/deserialized:
> By design, [::load](https://ruby-doc.org/core-2.3.3/Marshal.html#method-c-load) can deserialize almost any class loaded into the Ruby process. In many cases this can lead to remote code execution if the [Marshal](https://ruby-doc.org/core-2.3.3/Marshal.html) data is loaded from an untrusted source.
>
> As a result, [::load](https://ruby-doc.org/core-2.3.3/Marshal.html#method-c-load) is not suitable as a general purpose serialization format and you should never unmarshal user supplied input or other untrusted data.
>
> If you need to deserialize untrusted data, use JSON or another serialization format that is only able to load simple, 'primitive' types such as [String](https://ruby-doc.org/core-2.3.3/String.html), [Array](https://ruby-doc.org/core-2.3.3/Array.html), [Hash](https://ruby-doc.org/core-2.3.3/Hash.html), etc. Never allow user input to specify arbitrary types to deserialize into.

**Note:** This also refactors the `HashBackend` class name to `MemoryBackend` for added clarity over the backend implementation used to store data.

Closes #51 

