### PR TITLE
Fix pending tests

### DIFF
--- a/lib/basket/backend_adapter/memory_backend.rb
+++ b/lib/basket/backend_adapter/memory_backend.rb
@@ -29,6 +29,8 @@ module Basket
       def remove(queue, id)
         index_of_element_to_delete = @data[queue].index { |element| element.id == id }
         @data[queue].delete_at(index_of_element_to_delete)
+      rescue
+        nil
       end
 
       def clear(queue)

--- a/lib/basket/error.rb
+++ b/lib/basket/error.rb
@@ -2,4 +2,6 @@ module Basket
   class Error < StandardError; end
 
   class BasketNotFoundError < Error; end
+
+  class EmptyBasketError < Error; end
 end

--- a/lib/basket/error.rb
+++ b/lib/basket/error.rb
@@ -4,4 +4,6 @@ module Basket
   class BasketNotFoundError < Error; end
 
   class EmptyBasketError < Error; end
+
+  class ElementNotFoundError < Error; end
 end

--- a/lib/basket/queue_collection.rb
+++ b/lib/basket/queue_collection.rb
@@ -28,6 +28,7 @@ module Basket
 
     def remove(queue, id)
       raw_removed_element = @backend.remove(queue, id)
+      check_for_raw_removed_element(raw_removed_element)
       Element.from_queue(raw_removed_element).data
     end
 
@@ -51,6 +52,10 @@ module Basket
 
     def check_for_zero_length(queue)
       raise Basket::EmptyBasketError, "The basket #{queue} is empty." if length(queue).zero?
+    end
+
+    def check_for_raw_removed_element(raw_removed_element)
+      raise Basket::ElementNotFoundError if raw_removed_element.nil?
     end
   end
 end

--- a/lib/basket/queue_collection.rb
+++ b/lib/basket/queue_collection.rb
@@ -19,6 +19,7 @@ module Basket
     end
 
     def search(queue, query)
+      raise Basket::EmptyBasketError, "The basket #{queue} is empty." if length(queue).zero?
       raw_search_results = @backend.search(queue, &query)
       raw_search_results.map { |raw_search_result| Element.from_queue(raw_search_result) }
     end

--- a/lib/basket/queue_collection.rb
+++ b/lib/basket/queue_collection.rb
@@ -14,12 +14,14 @@ module Basket
     end
 
     def read(queue)
+      check_for_basket(queue)
       raw_queue = @backend.read(queue)
       raw_queue.map { |element| Element.from_queue(element).data }
     end
 
     def search(queue, query)
-      raise Basket::EmptyBasketError, "The basket #{queue} is empty." if length(queue).zero?
+      check_for_basket(queue)
+      check_for_zero_length(queue)
       raw_search_results = @backend.search(queue, &query)
       raw_search_results.map { |raw_search_result| Element.from_queue(raw_search_result) }
     end
@@ -39,6 +41,16 @@ module Basket
 
     def reset_backend
       @backend = Basket.config.backend.new
+    end
+
+    private
+
+    def check_for_basket(queue)
+      raise Basket::BasketNotFoundError unless Object.const_defined?(queue)
+    end
+
+    def check_for_zero_length(queue)
+      raise Basket::EmptyBasketError, "The basket #{queue} is empty." if length(queue).zero?
     end
   end
 end

--- a/spec/basket/backend_adapter/memory_backend_spec.rb
+++ b/spec/basket/backend_adapter/memory_backend_spec.rb
@@ -113,6 +113,17 @@ RSpec.describe Basket::BackendAdapter::MemoryBackend do
       expect(result).to eq(element_to_delete)
       expect(backend.read("test_queue")).to eq([element_to_keep])
     end
+
+    context "when the id does not correspond to an element" do
+      it "returns nil" do
+        element_to_keep = Basket::Element.new({bing: :boop})
+        backend = described_class.new
+        backend.push("test_queue", element_to_keep)
+
+        result = backend.remove("test_queue", "not an id")
+        expect(result).to be_nil
+      end
+    end
   end
 
   describe "#clear" do

--- a/spec/basket/backend_adapter/redis_backend_spec.rb
+++ b/spec/basket/backend_adapter/redis_backend_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe Basket::BackendAdapter::RedisBackend do
 
       expect(result).to eq(JSON.parse(element_2.to_json))
     end
+
+    context "when the id does not correspond to an element" do
+      it "returns nil" do
+        backend = described_class.new
+        element_1 = Basket::Element.new({a: 1})
+        element_2 = Basket::Element.new({b: 2})
+
+        backend.push("test_queue", element_1)
+        backend.push("test_queue", element_2)
+
+        result = backend.remove("test_queue", "invalid_id")
+
+        expect(result).to be_nil
+      end
+    end
   end
 
   describe "#push" do

--- a/spec/basket/queue_collection_spec.rb
+++ b/spec/basket/queue_collection_spec.rb
@@ -127,12 +127,12 @@ RSpec.describe Basket::QueueCollection do
     it "clears the specified queue" do
       q = Basket::QueueCollection.new
 
-      q.push("StockBasket", {symbol: "AAPL", price: 100.00})
-      q.push("StockBasket", {symbol: "GOOG", price: 200.00})
+      q.push("DummyStockBasket", {symbol: "AAPL", price: 100.00})
+      q.push("DummyStockBasket", {symbol: "GOOG", price: 200.00})
 
-      q.clear("StockBasket")
+      q.clear("DummyStockBasket")
 
-      expect(q.read("StockBasket")).to eq([])
+      expect(q.read("DummyStockBasket")).to eq([])
     end
   end
 end

--- a/spec/basket_spec.rb
+++ b/spec/basket_spec.rb
@@ -81,6 +81,14 @@ class DummySearchAndDestroyBasket
   basket_options size: 10
 end
 
+class DummyEmptyBasket
+  include Basket::Batcher
+  basket_options size: 1
+
+  def perform
+  end
+end
+
 RSpec.describe Basket do
   it "has a version number" do
     expect(Basket::VERSION).not_to be nil
@@ -294,7 +302,14 @@ RSpec.describe Basket do
     end
 
     context "when you search on an empty basket" do
-      it "raises a Basket::EmptyBasketError"
+      it "raises a Basket::EmptyBasketError" do
+        Basket.add("DummyEmptyBasket", "")
+        expect(Basket.peek("DummyEmptyBasket")).to eq([])
+
+        expect {
+          Basket.search("DummyEmptyBasket") { |element| element.blip = "bloop" }
+        }.to raise_error(Basket::EmptyBasketError, /The basket DummyEmptyBasket is empty./)
+      end
     end
 
     context "when you search on a basket that doesn't exist" do

--- a/spec/basket_spec.rb
+++ b/spec/basket_spec.rb
@@ -236,8 +236,17 @@ RSpec.describe Basket do
     end
 
     context "when your search returns no results" do
-      # does it?
-      it "returns an empty array"
+      it "returns an empty array" do
+        Basket.add("PlaylistBasket", "The Beatles")
+        Basket.add("PlaylistBasket", "The Rolling Stones")
+        Basket.add("PlaylistBasket", "The Who")
+
+        results = Basket.search("PlaylistBasket") do |element|
+          element == "The Doors"
+        end
+
+        expect(results).to eq([])
+      end
     end
   end
 

--- a/spec/basket_spec.rb
+++ b/spec/basket_spec.rb
@@ -272,7 +272,12 @@ RSpec.describe Basket do
     end
 
     context "when the id does not exist" do
-      it "raise a Basket::ElementNotFoundError"
+      it "raise a Basket::ElementNotFoundError" do
+        onions = OpenStruct.new(food: "Onions", price: 1.99)
+        Basket.add("DummySearchAndDestroyBasket", onions)
+        element_to_delete_id = "non_existent_id"
+        expect { Basket.remove("DummySearchAndDestroyBasket", element_to_delete_id) }.to raise_error(Basket::ElementNotFoundError)
+      end
     end
   end
 

--- a/spec/features/queue_collection_with_redis_spec.rb
+++ b/spec/features/queue_collection_with_redis_spec.rb
@@ -60,6 +60,24 @@ RSpec.describe "Queue collection with Redis" do
       expect(results).to be_a(Array)
       expect(results.first).to be_a(Basket::Element)
     end
+
+    context "when the query does not match any elements" do
+      it "returns an empty array" do
+        query_proc = proc { |element| element["artist"] == "Bob Dylan" }
+
+        results = q.search("PlaylistBasket", query_proc)
+
+        expect(results).to be_empty
+      end
+    end
+
+    context "when the basket does not exist" do
+      it "raises basket not found error" do
+        query_proc = proc { |element| element["artist"] == "Bob Dylan" }
+
+        expect { q.search("NonexistentBasket", query_proc) }.to raise_error(Basket::BasketNotFoundError)
+      end
+    end
   end
 
   describe "#remove" do
@@ -78,6 +96,12 @@ RSpec.describe "Queue collection with Redis" do
       expect(q.length("PlaylistBasket")).to eq(1)
       expect(element_to_delete.data).to eq(deleted_element)
       expect(q.read("PlaylistBasket")).to eq([{"song" => "Sacred Feathers", "artist" => "Parra for Cuva, Senoy"}])
+    end
+
+    context "when the id does not exist" do
+      it "raises element not found error" do
+        expect { q.remove("PlaylistBasket", "not_an_id") }.to raise_error(Basket::ElementNotFoundError)
+      end
     end
   end
 end

--- a/spec/support/test_classes.rb
+++ b/spec/support/test_classes.rb
@@ -1,0 +1,102 @@
+class PlaylistBasket
+  include Basket::Batcher
+  basket_options size: 2
+
+  def perform
+    puts "Playing #{batch}"
+  end
+end
+
+class DummyGroceryBasket
+  include Basket::Batcher
+  basket_options size: 2
+
+  def perform
+    puts "Checkout"
+  end
+
+  def on_add
+    puts "Check coupons for #{element}"
+  end
+
+  def on_success
+    puts "Add #{batch} to bag"
+  end
+end
+
+class DummyStockBasket
+  include Basket::Batcher
+  basket_options size: 3
+
+  def perform
+    batch.each do |stock|
+      puts stock
+    end
+  end
+
+  def on_add
+    puts "Check for insider trading on #{element[:ticker]}"
+  end
+end
+
+class DummyFireworksBasket
+  include Basket::Batcher
+  basket_options size: 1
+
+  def perform
+    raise "Boom"
+  end
+
+  def on_failure
+    puts "wow, #{error.message} was loud"
+    raise error
+  end
+end
+
+class NonPerformantBasket
+  include Basket::Batcher
+  basket_options size: 1
+end
+
+class DummyErrorsBasket
+  include Basket::Batcher
+
+  def on_failure
+    raise "This Error isn't raised!"
+  end
+end
+
+class BatchBugBasket
+  include Basket::Batcher
+  basket_options size: 1
+
+  def on_add
+    puts batch
+  end
+
+  def perform
+    puts batch
+  end
+
+  def on_success
+    puts batch
+  end
+end
+
+class DummySearchAndDestroyBasket
+  include Basket::Batcher
+  basket_options size: 10
+end
+
+class DummyEmptyBasket
+  include Basket::Batcher
+  basket_options size: 1
+
+  def perform
+  end
+end
+
+class PizzaBasket
+  include Basket::Batcher
+  basket_options size: 10
+end


### PR DESCRIPTION
* moved test classes used in `basket_spec` to support folder.  This is because, if we are guarding on whether or not the classes exist now, our tests in queue adapter start to break.  This way we don't have to duplicate classes.  Down side is I don't like the test classes being so far away from the assertions.

## Questions

* we don't let you search on non-existent baskets.  why can you peek at them or do any other thing?
  * should we guard every method in the queue colelction?
* would it be nicer that when you search it returns a result object instead of an empty array?

closes #61 