### PR TITLE
Perform when basket is over capacity

### DIFF
--- a/lib/basket/handle_add.rb
+++ b/lib/basket/handle_add.rb
@@ -53,7 +53,7 @@ module Basket
     end
 
     def basket_full?(queue_length, queue_class)
-      queue_length == queue_class.basket_options_hash[:size]
+      queue_length >= queue_class.basket_options_hash[:size]
     end
 
     def maybe_raise_basket_error(e)

--- a/spec/basket_spec.rb
+++ b/spec/basket_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe Basket do
         end.to raise_error(Basket::Error, "You must implement perform in your Basket class.")
       end
     end
+
+    context "when the basket is over capacity" do
+      it "processes the batch" do
+        Basket.queue_collection.push("DummyGroceryBasket", :milk)
+        Basket.queue_collection.push("DummyGroceryBasket", :cookies)
+
+        Basket.add("DummyGroceryBasket", :eggs)
+
+        expect($stdout).to have_received(:puts).with("Checkout")
+      end
+    end
   end
 
   describe ".on_add" do


### PR DESCRIPTION
## Description of Changes
In some cases the basket might end up with more entries than the `queue_class.basket_options_hash[:size]` which prevents the basket from ever performing/or being cleared.

These scenarios could happen when a certain record is added to the queue_collection but the `on_success` or `perform` raises an exception prior to the basket being cleared — and a subsequent `Basket.add` pushes the basket capacity passed the defined size.

In this scenario ^, we likely want to ensure the basket can be cleared/performed when the underlying issue that raised an exception is addressed.

_An alternative approach would be to clear the queue as part of the error handling, though that would result in losing unprocessed elements, which might be more disruptive._