### PR TITLE
Remove Code Climate integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,12 +21,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Setup Code Climate test-reporter
-      run: |
-        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        chmod +x ./cc-test-reporter
-        ./cc-test-reporter before-build
     - name: Run the default task
       run: bundle exec rake
-    - name: Publish code coverage
-      run: ./cc-test-reporter after-build -r ${{secrets.CODE_CLIMATE_REPORTER_ID}}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [![Gem Version](https://badge.fury.io/rb/basket.svg)](https://badge.fury.io/rb/basket)
 [![Ruby Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://github.com/testdouble/standard)
 [![Tests](https://github.com/nicholalexander/basket/actions/workflows/main.yml/badge.svg)](https://github.com/nicholalexander/basket/actions/workflows/main.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/dab6a6e193cbd9df2b3e/maintainability)](https://codeclimate.com/github/nicholalexander/basket/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/dab6a6e193cbd9df2b3e/test_coverage)](https://codeclimate.com/github/nicholalexander/basket/test_coverage)
 # Basket
 
 A farmer doesn't walk down to the chicken coop, grab an egg, go back to the kitchen, go back to the coop, go back to the kitchen ad infinitum.  They take a basket with them, and as the chickens lay their eggs, they fill up the basket and when the basket is full they go make something with them!  I would make a quiche, but that's besides the case.


### PR DESCRIPTION
The Code Climate test reporter has been deprecated and the download URL no longer works (codeclimate/test-reporter was archived July 2025).

- Remove Code Climate setup and publish steps from CI workflow
- Remove Maintainability and Test Coverage badges from README

## Description of Changes

## Related Issue

## Tags